### PR TITLE
enhancement: do not redeploy on custom data changes

### DIFF
--- a/main.linux.tf
+++ b/main.linux.tf
@@ -163,7 +163,10 @@ resource "azurerm_linux_virtual_machine" "this" {
 
   # https://github.com/hashicorp/terraform-provider-azurerm/issues/27484
   lifecycle {
-    ignore_changes = [vm_agent_platform_updates_enabled]
+    ignore_changes = [
+      vm_agent_platform_updates_enabled,
+      custom_data
+    ]
   }
 }
 

--- a/main.windows.tf
+++ b/main.windows.tf
@@ -177,7 +177,8 @@ resource "azurerm_windows_virtual_machine" "this" {
   lifecycle {
     ignore_changes = [
       winrm_listener, # Once the certificate got rotated, it will triger a destroy/recreate of the VM.
-      admin_password  # Once the password got removed, it will triger a destroy/recreate of the VM.
+      admin_password,  # Once the password got removed, it will triger a destroy/recreate of the VM.
+      custom_data
     ]
   }
 }

--- a/main.windows.tf
+++ b/main.windows.tf
@@ -177,7 +177,7 @@ resource "azurerm_windows_virtual_machine" "this" {
   lifecycle {
     ignore_changes = [
       winrm_listener, # Once the certificate got rotated, it will triger a destroy/recreate of the VM.
-      admin_password,  # Once the password got removed, it will triger a destroy/recreate of the VM.
+      admin_password, # Once the password got removed, it will triger a destroy/recreate of the VM.
       custom_data
     ]
   }


### PR DESCRIPTION
do not redeploy on custom data changes, this should be a manual task.
currently with every change of the custom_data it wants to redeploy the vm, which is a bit overkill