### PR TITLE
bug: Added ignores for properties changed when a VM (disk) is restored

### DIFF
--- a/main.disks.tf
+++ b/main.disks.tf
@@ -50,6 +50,14 @@ resource "azurerm_managed_disk" "this" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      create_option,
+      image_reference_id,
+      gallery_image_reference_id
+    ]
+  }
 }
 
 #attach the disk(s) to the virtual machine
@@ -62,6 +70,12 @@ resource "azurerm_virtual_machine_data_disk_attachment" "this_linux" {
   virtual_machine_id        = azurerm_linux_virtual_machine.this[0].id
   create_option             = each.value.disk_attachment_create_option
   write_accelerator_enabled = each.value.write_accelerator_enabled
+
+  lifecycle {
+    ignore_changes = [
+      create_option
+    ]
+  }
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "this_windows" {
@@ -73,4 +87,10 @@ resource "azurerm_virtual_machine_data_disk_attachment" "this_windows" {
   virtual_machine_id        = azurerm_windows_virtual_machine.this[0].id
   create_option             = each.value.disk_attachment_create_option
   write_accelerator_enabled = each.value.write_accelerator_enabled
+
+  lifecycle {
+    ignore_changes = [
+      create_option
+    ]
+  }
 }


### PR DESCRIPTION
## :hammer_and_wrench: Summary

When we restore a Virtual Machine disk, the following properties will change:
- createOption
- imageReference
- gallery_image_reference_id

When this happens, Terrform will attempt to switch it back to the previous value, but the operation will not be allowed, thus the pipeline will fail.
 
## :rocket: Motivation

So that we can execute IaC pipelines with Terraform after VM disks are restored from Azure Backup, DMS or Snapshots. 

## :pencil: Additional Information

N/A
